### PR TITLE
Add goals and recipe features

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,15 @@
+name: Node.js CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data.json.bak

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# tracknutri
+# TrackNutri
+
+Une application simple pour suivre les nutriments de vos repas. Elle fournit une interface web responsive pour ajouter des aliments, fixer des objectifs quotidiens et analyser des recettes.
+
+## Lancer l'application en local
+
+```bash
+node server.js
+```
+
+L'application sera disponible sur [http://localhost:3000](http://localhost:3000).
+
+## Déploiement sur Render
+
+1. Créez un nouveau service Web sur Render et connectez ce dépôt.
+2. Utilisez la commande de démarrage suivante :
+   ```bash
+   node server.js
+   ```
+3. Le port est défini via la variable d'environnement `PORT` automatiquement par Render.
+
+Les données sont enregistrées dans `data.json`. Pour une utilisation en production, envisagez d'utiliser une base de données persistante.
+
+## Tests
+
+```bash
+npm test
+```
+
+Des tests Jest vérifient la présence des fichiers principaux. Un workflow GitHub Actions exécute automatiquement ces tests à chaque pull request.

--- a/data.json
+++ b/data.json
@@ -1,0 +1,1 @@
+{"entries": [], "goals": {"calories": 0, "protein": 0, "carbs": 0, "fat": 0}}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tracknutri",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "jest",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,91 @@
+let chart;
+
+async function loadEntries() {
+  const res = await fetch('/api/entries');
+  const data = await res.json();
+  const tbody = document.querySelector('#entriesTable tbody');
+  tbody.innerHTML = '';
+  data.forEach(e => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${e.date}</td><td>${e.name}</td><td>${e.calories}</td><td>${e.protein}</td><td>${e.carbs}</td><td>${e.fat}</td>`;
+    tbody.appendChild(tr);
+  });
+  updateChart(data);
+}
+
+async function loadGoals() {
+  const res = await fetch('/api/goals');
+  const goals = await res.json();
+  document.getElementById('gcalories').value = goals.calories;
+  document.getElementById('gprotein').value = goals.protein;
+  document.getElementById('gcarbs').value = goals.carbs;
+  document.getElementById('gfat').value = goals.fat;
+}
+
+async function saveGoals(e) {
+  e.preventDefault();
+  const goals = {
+    calories: parseInt(document.getElementById('gcalories').value, 10),
+    protein: parseInt(document.getElementById('gprotein').value, 10),
+    carbs: parseInt(document.getElementById('gcarbs').value, 10),
+    fat: parseInt(document.getElementById('gfat').value, 10)
+  };
+  await fetch('/api/goals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(goals)
+  });
+  updateChart();
+}
+
+function updateChart(entriesData) {
+  if (!entriesData) return;
+  const totals = entriesData.reduce((acc, e) => {
+    if (e.date === new Date().toISOString().slice(0,10)) {
+      acc.calories += e.calories;
+      acc.protein += e.protein;
+      acc.carbs += e.carbs;
+      acc.fat += e.fat;
+    }
+    return acc;
+  }, {calories:0, protein:0, carbs:0, fat:0});
+  fetch('/api/goals').then(r=>r.json()).then(goals=>{
+    const ctx = document.getElementById('progressChart');
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ['Calories','Protéines','Glucides','Lipides'],
+        datasets: [
+          { label: 'Consommé', data: [totals.calories, totals.protein, totals.carbs, totals.fat], backgroundColor: 'rgba(54, 162, 235, 0.5)' },
+          { label: 'Objectif', data: [goals.calories, goals.protein, goals.carbs, goals.fat], backgroundColor: 'rgba(255, 99, 132, 0.5)' }
+        ]
+      },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+  });
+}
+
+async function addEntry(e) {
+  e.preventDefault();
+  const entry = {
+    name: document.getElementById('name').value,
+    calories: parseInt(document.getElementById('calories').value, 10),
+    protein: parseInt(document.getElementById('protein').value, 10),
+    carbs: parseInt(document.getElementById('carbs').value, 10),
+    fat: parseInt(document.getElementById('fat').value, 10),
+    date: new Date().toISOString().slice(0,10)
+  };
+  await fetch('/api/entries', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(entry)
+  });
+  e.target.reset();
+  loadEntries();
+}
+
+document.getElementById('entryForm').addEventListener('submit', addEntry);
+document.getElementById('goalsForm').addEventListener('submit', saveGoals);
+loadEntries();
+loadGoals();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TrackNutri</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+</head>
+<body class="container py-3">
+  <h1 class="mb-4">TrackNutri</h1>
+
+  <div class="card p-3 mb-4">
+    <h2 class="h4">Objectifs quotidiens</h2>
+    <form id="goalsForm" class="row g-3 align-items-end">
+      <div class="col-md-2">
+        <label for="gcalories" class="form-label">Calories</label>
+        <input type="number" class="form-control" id="gcalories" required>
+      </div>
+      <div class="col-md-2">
+        <label for="gprotein" class="form-label">Protéines (g)</label>
+        <input type="number" class="form-control" id="gprotein" required>
+      </div>
+      <div class="col-md-2">
+        <label for="gcarbs" class="form-label">Glucides (g)</label>
+        <input type="number" class="form-control" id="gcarbs" required>
+      </div>
+      <div class="col-md-2">
+        <label for="gfat" class="form-label">Lipides (g)</label>
+        <input type="number" class="form-control" id="gfat" required>
+      </div>
+      <div class="col-md-2 d-grid">
+        <button type="submit" class="btn btn-success">Enregistrer</button>
+      </div>
+    </form>
+    <canvas id="progressChart" class="mt-3"></canvas>
+  </div>
+
+  <form id="entryForm" class="row g-3">
+    <div class="col-md-3">
+      <input type="text" class="form-control" id="name" placeholder="Aliment" required>
+    </div>
+    <div class="col-md-2">
+      <input type="number" class="form-control" id="calories" placeholder="Calories" required>
+    </div>
+    <div class="col-md-2">
+      <input type="number" class="form-control" id="protein" placeholder="Protéines (g)" required>
+    </div>
+    <div class="col-md-2">
+      <input type="number" class="form-control" id="carbs" placeholder="Glucides (g)" required>
+    </div>
+    <div class="col-md-2">
+      <input type="number" class="form-control" id="fat" placeholder="Lipides (g)" required>
+    </div>
+    <div class="col-md-1 d-grid">
+      <button type="submit" class="btn btn-primary">Ajouter</button>
+    </div>
+  </form>
+
+  <table class="table table-striped mt-4" id="entriesTable">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Aliment</th>
+        <th>Calories</th>
+        <th>Protéines</th>
+        <th>Glucides</th>
+        <th>Lipides</th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,9 @@
+body {
+  font-family: Arial, sans-serif;
+}
+
+@media (max-width: 576px) {
+  h1 {
+    font-size: 1.5rem;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,139 @@
+const http = require('http');
+const fs = require('fs').promises;
+const path = require('path');
+
+const DATA_FILE = path.join(__dirname, 'data.json');
+let writeQueue = Promise.resolve();
+
+async function readData() {
+  try {
+    const raw = await fs.readFile(DATA_FILE, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    return { entries: [], goals: { calories:0, protein:0, carbs:0, fat:0 } };
+  }
+}
+
+async function backupData() {
+  try {
+    await fs.copyFile(DATA_FILE, `${DATA_FILE}.bak`);
+  } catch {}
+}
+
+function writeData(data) {
+  writeQueue = writeQueue.then(async () => {
+    await fs.writeFile(DATA_FILE, JSON.stringify(data, null, 2));
+    await backupData();
+  });
+  return writeQueue;
+}
+
+const server = http.createServer(async (req, res) => {
+  const { method, url } = req;
+
+  if (url.startsWith('/api/entries')) {
+    if (method === 'GET') {
+      const data = await readData();
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(data.entries));
+    } else if (method === 'POST') {
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk.toString();
+      });
+      req.on('end', async () => {
+        try {
+          const entry = JSON.parse(body);
+          const data = await readData();
+          data.entries.push({ ...entry, id: Date.now() });
+          await writeData(data);
+          res.statusCode = 201;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ success: true }));
+        } catch (err) {
+          res.statusCode = 400;
+          res.end('Invalid JSON');
+        }
+      });
+    } else {
+      res.statusCode = 405;
+      res.end('Method Not Allowed');
+    }
+    return;
+  }
+
+  if (url.startsWith('/api/goals')) {
+    if (method === 'GET') {
+      const data = await readData();
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(data.goals));
+    } else if (method === 'POST') {
+      let body = '';
+      req.on('data', chunk => body += chunk.toString());
+      req.on('end', async () => {
+        try {
+          const goals = JSON.parse(body);
+          const data = await readData();
+          data.goals = goals;
+          await writeData(data);
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ success: true }));
+        } catch (err) {
+          res.statusCode = 400;
+          res.end('Invalid JSON');
+        }
+      });
+    } else {
+      res.statusCode = 405;
+      res.end('Method Not Allowed');
+    }
+    return;
+  }
+
+  if (url === '/api/recipes' && method === 'POST') {
+    let body = '';
+    req.on('data', chunk => body += chunk.toString());
+    req.on('end', () => {
+      try {
+        const recipe = JSON.parse(body);
+        const totals = recipe.ingredients.reduce((acc, ing) => {
+          acc.calories += ing.calories;
+          acc.protein += ing.protein;
+          acc.carbs += ing.carbs;
+          acc.fat += ing.fat;
+          return acc;
+        }, {calories:0, protein:0, carbs:0, fat:0});
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(totals));
+      } catch {
+        res.statusCode = 400;
+        res.end('Invalid JSON');
+      }
+    });
+    return;
+  }
+
+  // serve static files
+  const filePath = url === '/' ? 'index.html' : url.slice(1);
+  const fullPath = path.join(__dirname, 'public', filePath);
+  try {
+    const data = await fs.readFile(fullPath);
+    if (filePath.endsWith('.js')) {
+      res.setHeader('Content-Type', 'application/javascript');
+    } else if (filePath.endsWith('.css')) {
+      res.setHeader('Content-Type', 'text/css');
+    } else {
+      res.setHeader('Content-Type', 'text/html');
+    }
+    res.end(data);
+  } catch {
+    res.statusCode = 404;
+    res.end('Not Found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+test('server.js exists', () => {
+  expect(fs.existsSync('server.js')).toBe(true);
+});
+
+test('index.html exists', () => {
+  expect(fs.existsSync('public/index.html')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add daily goals form and progress chart
- use async fs with backup and simple locking
- add endpoints for goals and recipe analysis
- switch tests to jest and set up GitHub Actions
- document tests and ignore backups

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845eb2e2798833285b4673420fab220